### PR TITLE
Add ability to normalize scrolling speed for wheel events

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,33 @@ Every time tabs change and or the tab container resizes, update the scroller:
 scroller.update();
 ```
 
+### (optional) Pass a `normalizeWheel` function to options to normalize scrolling speed:
+
+Every time user uses wheel or touchpad to scroll tabs `eventHandler` will be called.
+
+```javascript
+function normalizeWheel(scroll) {
+  ...
+  return function eventHandler(event) {
+    event.preventDefault();
+
+    ...
+
+    scroll(direction);
+  }
+}
+
+var scroller = scrollTabs(tabBarNode, {
+  selectors: {
+    tabsContainer: '.my-tabs-container',
+    tab: '.my-tab',
+    ignore: '.ignore-me',
+    active: '.i-am-active'
+  },
+  normalizeWheel: normalizeWheel
+});
+```
+
 ## How to test
 
 ```

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ import createEmitter from 'mitt';
 
 var DEFAULT_OPTIONS = {
   scrollSymbolLeft: '‹',
-  scrollSymbolRight: '›'
+  scrollSymbolRight: '›',
+  normalizeWheel: normalizeWheel
 };
 
 
@@ -33,6 +34,11 @@ var DEFAULT_OPTIONS = {
  * a 'scroll' event is being fired. This event contains the node elements
  * of the new and old active tab, and the direction in which the tab has
  * changed relative to the old active tab.
+ *
+ * Optionally, you can add to config a `normalizeWheel` option. This should
+ * be a function returning an event handler which should pass a `Number` to
+ * received callback. With custom `normalizeWheel` function you can normalize
+ * scrolling speed between browsers and devices (touch pad, mouse).
  *
  * @example:
  * (1) provide a tabs-container:
@@ -77,6 +83,38 @@ var DEFAULT_OPTIONS = {
  * scroller.update();
  *
  *
+ * (optionally) pass a `normalizeWheel` function to options to throttle scroll events:
+ *
+ *  function normalizeWheel(scroll) {
+ *    var throttled = false;
+ *
+ *    return function(event) {
+ *      var direction = Math.sign(event.deltaY);
+ *
+ *      event.preventDefault();
+ *
+ *      if (!throttled) {
+ *        throttled = true;
+ *        setTimeout(function() {
+ *          throttled = false;
+ *        }, 50)
+ *
+ *        scroll(direction);
+ *      }
+ *    }
+ *  }
+ *
+ *  var scroller = scrollTabs(tabBarNode, {
+ *    selectors: {
+ *      tabsContainer: '.my-tabs-container',
+ *      tab: '.my-tab',
+ *      ignore: '.ignore-me',
+ *      active: '.i-am-active'
+ *    },
+ *    normalizeWheel: normalizeWheel
+ *  });
+ *
+ *
  * @param  {DOMElement} el
  * @param  {Object} options
  * @param  {Object} options.selectors
@@ -86,6 +124,7 @@ var DEFAULT_OPTIONS = {
  * @param  {String} options.selectors.active selector for the current active tab
  * @param  {String} [options.scrollSymbolLeft]
  * @param  {String} [options.scrollSymbolRight]
+ * @param  {Function} [options.normalizeWheel] middleware function to normalize scrolling speed
  */
 function ScrollTabs($el, options) {
 
@@ -254,13 +293,10 @@ ScrollTabs.prototype._bindTabClickEvents = function(node) {
  * @param {DOMElement} node
  */
 ScrollTabs.prototype._bindWheelEvent = function(node) {
-  var self = this;
+  var self = this,
+      normalizeWheel = this.options.normalizeWheel;
 
-  domEvent.bind(node, 'wheel', function(e) {
-
-    // scroll direction (-1: left, 1: right)
-    var direction = Math.sign(e.deltaY);
-
+  domEvent.bind(node, 'wheel', normalizeWheel(function(direction) {
     var oldActiveTab = self.getActiveTabNode();
 
     var newActiveTab = self.getAdjacentTab(oldActiveTab, direction);
@@ -269,9 +305,7 @@ ScrollTabs.prototype._bindWheelEvent = function(node) {
       self.scrollToTabNode(newActiveTab);
       self.emit('scroll', newActiveTab, oldActiveTab, direction);
     }
-
-    e.preventDefault();
-  });
+  }));
 };
 
 /**
@@ -391,3 +425,22 @@ function get($el) {
 }
 
 create.get = get;
+
+
+
+// helpers ////////////////
+
+function normalizeWheel(scroll) {
+  /**
+   * @param {WheelEvent} event
+   */
+  function normalizedScroll(event) {
+    var direction = Math.sign(event.deltaY);
+
+    event.preventDefault();
+
+    return scroll(direction);
+  }
+
+  return normalizedScroll;
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "author": "bpmn.io <http://bpmn.io>",
   "license": "MIT",
   "devDependencies": {
+    "babel-preset-env": "^1.7.0",
     "chai": "^3.5.0",
     "eslint": "^5.2.0",
     "eslint-plugin-bpmn-io": "^0.5.3",

--- a/test.js
+++ b/test.js
@@ -1,3 +1,5 @@
+/* global sinon */
+
 import scrollTabs from '.';
 
 import {
@@ -85,8 +87,96 @@ describe('scrollTabs', function() {
   });
 
 
-  it('scrolling');
+  describe('scrolling', function() {
+
+    it('should scroll for each wheel event per default', function() {
+
+      // given
+      var scrollSpy = sinon.spy();
+
+      if (!Math.sign) {
+        Math.sign = signPolyfill;
+      }
+
+      var scroller = scrollTabs(node, {
+        selectors: {
+          tabsContainer: '.my-tabs-container',
+          tab: '.my-tab',
+          ignore: '.ignore-me',
+          active: '.i-am-active'
+        }
+      });
+
+      scroller.on('scroll', scrollSpy);
+
+      // when
+      var wheelEvent = getWheelEvent(1);
+
+      node.dispatchEvent(wheelEvent);
+      node.dispatchEvent(wheelEvent);
+
+      // then
+      expect(scrollSpy).to.be.calledTwice;
+    });
+
+
+    it('should allow to use a custom function to normalize scrolling speed', function() {
+
+      // given
+      var eventHandlerSpy = sinon.spy(),
+          normalizeWheelStub = sinon.stub().returns(eventHandlerSpy);
+
+      scrollTabs(node, {
+        selectors: {
+          tabsContainer: '.my-tabs-container',
+          tab: '.my-tab',
+          ignore: '.ignore-me',
+          active: '.i-am-active'
+        },
+        normalizeWheel: normalizeWheelStub
+      });
+
+      // when
+      var wheelEvent = getWheelEvent(1);
+
+      node.dispatchEvent(wheelEvent);
+      node.dispatchEvent(wheelEvent);
+
+      // then
+      expect(normalizeWheelStub).to.be.calledOnce;
+      expect(eventHandlerSpy).to.be.calledTwice;
+      expect(eventHandlerSpy).to.be.calledWith(wheelEvent);
+    });
+
+  });
+
 
   it('update');
 
 });
+
+
+
+// helpers /////////
+
+function getWheelEvent(deltaY) {
+  var event;
+
+  try {
+    event = new WheelEvent('wheel', { deltaY: deltaY });
+  } catch (error) {
+    event = document.createEvent('CustomEvent');
+    event.initCustomEvent('wheel');
+    event.deltaY = deltaY;
+  }
+
+  return event;
+}
+
+/**
+ * Polyfill for `Math.sign` for PhantomJS
+ * @param {any} value
+ */
+function signPolyfill(value) {
+  return (value > 0 ? 1 : 0) + (value < 0 ? -1 : 0) || +value;
+}


### PR DESCRIPTION
This PR adds ability to pass a middleware function responsible for scrolling speed normalization. By adding this, it will be possible to overcome problems caused by different rate of dispatched `WheelEvent`s when using mouse or touch pad. Documentation is updated accordingly.

At the moment, UX for classic mouse user is quite good. However, users of MagicMouse or touch pads experience super fast scrolling. This PR will allow to normalize scrolling speed so that both groups can  fully use the library.

In 69a4c54 a missing dependency was added. Without this babel throwed errors when using library with `npm link`.